### PR TITLE
release v3.0.0 of eslint-config (dependency upgrades)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -584,20 +584,20 @@
       }
     },
     "node_modules/@microsoft/tsdoc": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
-      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@microsoft/tsdoc-config": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz",
-      "integrity": "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.0.tgz",
+      "integrity": "sha512-8N/vClYyfOH+l4fLkkr9+myAoR6M7akc8ntBJ4DJdWH2b09uVfr71+LTMpNyG19fNqWDg8KEDZhx5wxuqHyGjw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@microsoft/tsdoc": "0.15.1",
+        "@microsoft/tsdoc": "0.16.0",
         "ajv": "~8.12.0",
         "jju": "~1.4.0",
         "resolve": "~1.22.2"
@@ -4803,14 +4803,183 @@
       }
     },
     "node_modules/eslint-plugin-tsdoc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.4.0.tgz",
-      "integrity": "sha512-MT/8b4aKLdDClnS8mP3R/JNjg29i0Oyqd/0ym6NnQf+gfKbJJ4ZcSh2Bs1H0YiUMTBwww5JwXGTWot/RwyJ7aQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.5.0.tgz",
+      "integrity": "sha512-ush8ehCwub2rgE16OIgQPFyj/o0k3T8kL++9IrAI4knsmupNo8gvfO2ERgDHWWgTC5MglbwLVRswU93HyXqNpw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@microsoft/tsdoc": "0.15.1",
-        "@microsoft/tsdoc-config": "0.17.1"
+        "@microsoft/tsdoc": "0.16.0",
+        "@microsoft/tsdoc-config": "0.18.0",
+        "@typescript-eslint/utils": "~8.46.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/project-service": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.4.tgz",
+      "integrity": "sha512-nPiRSKuvtTN+no/2N1kt2tUh/HoFzeEgOm9fQ6XQk4/ApGqjx0zFIIaLJ6wooR1HIoozvj2j6vTi/1fgAz7UYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.46.4",
+        "@typescript-eslint/types": "^8.46.4",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.4.tgz",
+      "integrity": "sha512-tMDbLGXb1wC+McN1M6QeDx7P7c0UWO5z9CXqp7J8E+xGcJuUuevWKxuG8j41FoweS3+L41SkyKKkia16jpX7CA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/visitor-keys": "8.46.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.4.tgz",
+      "integrity": "sha512-+/XqaZPIAk6Cjg7NWgSGe27X4zMGqrFqZ8atJsX3CWxH/jACqWnrWI68h7nHQld0y+k9eTTjb9r+KU4twLoo9A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/types": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.4.tgz",
+      "integrity": "sha512-USjyxm3gQEePdUwJBFjjGNG18xY9A2grDVGuk7/9AkjIF1L+ZrVnwR5VAU5JXtUnBL/Nwt3H31KlRDaksnM7/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.4.tgz",
+      "integrity": "sha512-7oV2qEOr1d4NWNmpXLR35LvCfOkTNymY9oyW+lUHkmCno7aOmIf/hMaydnJBUTBMRCOGZh8YjkFOc8dadEoNGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.46.4",
+        "@typescript-eslint/tsconfig-utils": "8.46.4",
+        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/visitor-keys": "8.46.4",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/utils": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.4.tgz",
+      "integrity": "sha512-AbSv11fklGXV6T28dp2Me04Uw90R2iJ30g2bgLz529Koehrmkbs1r7paFqr1vPCZi7hHwYxYtxfyQMRC8QaVSg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.46.4",
+        "@typescript-eslint/types": "8.46.4",
+        "@typescript-eslint/typescript-estree": "8.46.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.46.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.4.tgz",
+      "integrity": "sha512-/++5CYLQqsO9HFGLI7APrxBJYo+5OCMpViuhV8q5/Qa3o5mMrF//eQHks+PXcsAVaLdn817fMuS7zqoXNNZGaw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.46.4",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-rule-documentation": {
@@ -11698,7 +11867,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.0.0",
         "eslint-plugin-react-hooks": "^5.0.0",
-        "eslint-plugin-tsdoc": "^0.4.0",
+        "eslint-plugin-tsdoc": "^0.5.0",
         "globals": "^16.0.0",
         "prettier": "^3.0.0",
         "typescript": ">=4.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4409,15 +4409,16 @@
       }
     },
     "node_modules/eslint-plugin-array-func": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-array-func/-/eslint-plugin-array-func-4.0.0.tgz",
-      "integrity": "sha512-p3NY2idNIvgmQLF2/62ZskYt8gOuUgQ51smRc3Lh7FtSozpNc2sg+lniz9VaCagLZHEZTl8qGJKqE7xy8O/D/g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-array-func/-/eslint-plugin-array-func-5.1.0.tgz",
+      "integrity": "sha512-+OULB0IQdENBmBf8pHMPPObgV6QyfeXFin483jPonOaiurI9UFmc8UydWriK5f5Gel8xBhQLA6NzMwbck1BUJw==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.40.0"
+        "eslint": ">=8.51.0"
       }
     },
     "node_modules/eslint-plugin-es-x": {
@@ -11840,7 +11841,7 @@
     },
     "packages/eslint-config": {
       "name": "@xrplf/eslint-config",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "confusing-browser-globals": "^1.0.11"
@@ -11859,7 +11860,7 @@
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-import-resolver-typescript": "^4.0.0",
-        "eslint-plugin-array-func": "^4.0.0",
+        "eslint-plugin-array-func": "^5.1.0",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsdoc": "^52.0.0",
         "eslint-plugin-jsx-a11y": "^6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11841,7 +11841,7 @@
     },
     "packages/eslint-config": {
       "name": "@xrplf/eslint-config",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "confusing-browser-globals": "^1.0.11"
@@ -11860,7 +11860,7 @@
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-import-resolver-typescript": "^4.0.0",
-        "eslint-plugin-array-func": "^5.1.0",
+        "eslint-plugin-array-func": "^5.0.0",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsdoc": "^52.0.0",
         "eslint-plugin-jsx-a11y": "^6.0.0",

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## 2.1.0
+- Upgrades `eslint-plugin-tsdoc` dependency from 0.4.0 to 0.5.0.
+- Upgrades the dependency `eslint-plugin-array-doc` from 4.0.0 to 5.1.0. Due to this upgrade, the `eslint-config` had to be converted from CommonJS to an ESM compatible implementation. This is because the said dependency only works with ESM modules.
+
+## 2.0.0
 - Migrated ESLint, and it's related plugins to their latest major version. [Breaking Change]
 - @xrplf/eslint-config version 2.0.0 now exports Flat configs that are equivalent to ^1.0.0 in terms of configuration rules barring some breaking changes there were introduced by ESLint itself, and other ESLint plugins that this shared config exported. See [V2_MIGRATION.md](./V2_MIGRATION.md). [Breaking Change]
 

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 3.0.0
 - Upgrades `eslint-plugin-tsdoc` dependency from 0.4.0 to 0.5.0.
-- Upgrades the dependency `eslint-plugin-array-doc` from 4.0.0 to 5.1.0. Due to this upgrade, the `eslint-config` had to be converted from CommonJS to an ESM compatible implementation. This is because the said dependency only works with ESM modules.
+- Upgrades the dependency `eslint-plugin-array-func` from 4.0.0 to 5.1.0. Due to this upgrade, the `eslint-config` had to be converted from CommonJS to an ESM compatible implementation. This is because the said dependency only works with ESM modules.
 - Note: There is no behavioral change in the linter rules enforced by this package.
 
 ## 2.0.0

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## 2.1.0
+## 3.0.0
 - Upgrades `eslint-plugin-tsdoc` dependency from 0.4.0 to 0.5.0.
 - Upgrades the dependency `eslint-plugin-array-doc` from 4.0.0 to 5.1.0. Due to this upgrade, the `eslint-config` had to be converted from CommonJS to an ESM compatible implementation. This is because the said dependency only works with ESM modules.
+- Note: There is no behavioral change in the linter rules enforced by this package.
 
 ## 2.0.0
 - Migrated ESLint, and it's related plugins to their latest major version. [Breaking Change]

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -1,22 +1,22 @@
-const eslint = require('@eslint/js')
-const globals = require('globals')
+import eslint from '@eslint/js'
+import globals from 'globals'
 
-const typescriptEslint = require('./rules/@typescript-eslint')
-const arrayFunc = require('./rules/array-func')
-const comments = require('./rules/eslint-comments')
-const bestPractices = require('./rules/eslint-core/best-practices')
-const errors = require('./rules/eslint-core/errors')
-const es6 = require('./rules/eslint-core/es6')
-const strict = require('./rules/eslint-core/strict')
-const style = require('./rules/eslint-core/style')
-const variables = require('./rules/eslint-core/variables')
-const importRules = require('./rules/import')
-const jsdoc = require('./rules/jsdoc')
-const node = require('./rules/node')
-const prettier = require('./rules/prettier')
-const tsdoc = require('./rules/tsdoc')
+import typescriptEslint from './rules/@typescript-eslint.js'
+import arrayFunc from './rules/array-func.js'
+import comments from './rules/eslint-comments.js'
+import bestPractices from './rules/eslint-core/best-practices.js'
+import errors from './rules/eslint-core/errors.js'
+import es6 from './rules/eslint-core/es6.js'
+import strict from './rules/eslint-core/strict.js'
+import style from './rules/eslint-core/style.js'
+import variables from './rules/eslint-core/variables.js'
+import importRules from './rules/import.js'
+import jsdoc from './rules/jsdoc.js'
+import node from './rules/node.js'
+import prettier from './rules/prettier.js'
+import tsdoc from './rules/tsdoc.js'
 
-module.exports = [
+export default [
   eslint.configs.recommended,
   ...errors,
   ...bestPractices,

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -1,6 +1,6 @@
-const baseConfig = require('./base')
+import baseConfig from './base.js'
 
-module.exports = [
+export default [
   ...baseConfig,
   {
     languageOptions: {
@@ -19,14 +19,17 @@ module.exports = [
       'import/unambiguous': 'off',
       'import/no-commonjs': 'off',
       'import/no-unused-modules': 'off',
+      // ESM requires .js extensions for relative imports
       'import/extensions': [
         'error',
         'ignorePackages',
         {
-          js: 'never',
+          js: 'always',
           mjs: 'always',
         },
       ],
+      // Allow anonymous default exports in ESLint config files
+      'import/no-anonymous-default-export': 'off',
     },
   },
 ]

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -19,14 +19,13 @@ export default [
       'import/unambiguous': 'off',
       'import/no-commonjs': 'off',
       'import/no-unused-modules': 'off',
-      // Allow anonymous default exports in ESLint config files
-      'import/no-anonymous-default-export': 'off',
     },
   },
-  // Override for this package only: ESM requires .js extensions for relative imports
+  // Overrides for this package only
   {
     files: ['*.js', 'rules/**/*.js'],
     rules: {
+      // ESM requires .js extensions for relative imports
       'import/extensions': [
         'error',
         'ignorePackages',
@@ -35,6 +34,8 @@ export default [
           mjs: 'always',
         },
       ],
+      // Allow anonymous default exports in ESLint config files
+      'import/no-anonymous-default-export': 'off',
     },
   },
 ]

--- a/packages/eslint-config/eslint.config.js
+++ b/packages/eslint-config/eslint.config.js
@@ -19,7 +19,14 @@ export default [
       'import/unambiguous': 'off',
       'import/no-commonjs': 'off',
       'import/no-unused-modules': 'off',
-      // ESM requires .js extensions for relative imports
+      // Allow anonymous default exports in ESLint config files
+      'import/no-anonymous-default-export': 'off',
+    },
+  },
+  // Override for this package only: ESM requires .js extensions for relative imports
+  {
+    files: ['*.js', 'rules/**/*.js'],
+    rules: {
       'import/extensions': [
         'error',
         'ignorePackages',
@@ -28,8 +35,6 @@ export default [
           mjs: 'always',
         },
       ],
-      // Allow anonymous default exports in ESLint config files
-      'import/no-anonymous-default-export': 'off',
     },
   },
 ]

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,4 +1,4 @@
-const base = require('./base')
-const react = require('./rules/react')
+import base from './base.js'
+import react from './rules/react.js'
 
-module.exports = [...react, ...base]
+export default [...react, ...base]

--- a/packages/eslint-config/loose-base.js
+++ b/packages/eslint-config/loose-base.js
@@ -1,7 +1,7 @@
-const base = require('./base')
-const common = require('./rules/common')
+import base from './base.js'
+import common from './rules/common.js'
 
-module.exports = [
+export default [
   ...base,
   {
     rules: {

--- a/packages/eslint-config/loose.js
+++ b/packages/eslint-config/loose.js
@@ -1,4 +1,4 @@
-const looseBase = require('./loose-base')
-const react = require('./rules/react')
+import looseBase from './loose-base.js'
+import react from './rules/react.js'
 
-module.exports = [...react, ...looseBase]
+export default [...react, ...looseBase]

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@xrplf/eslint-config",
   "version": "2.1.0",
+  "type": "module",
   "description": "The XRPL Foundation's base TypeScript ESLint config, following our styleguide",
   "keywords": [
     "eslint",
@@ -33,7 +34,7 @@
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-import-resolver-typescript": "^4.0.0",
-    "eslint-plugin-array-func": "^4.0.0",
+    "eslint-plugin-array-func": "^5.1.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsdoc": "^52.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -15,6 +15,12 @@
   },
   "license": "ISC",
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./base": "./base.js",
+    "./loose": "./loose.js",
+    "./loose-base": "./loose-base.js"
+  },
   "scripts": {
     "eslint-find-option-rules": "eslint-find-rules --flatConfig [option] <file> [flag]",
     "lint": "eslint .",
@@ -34,7 +40,7 @@
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-import-resolver-typescript": "^4.0.0",
-    "eslint-plugin-array-func": "^5.1.0",
+    "eslint-plugin-array-func": "^5.0.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsdoc": "^52.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.0.0",
     "eslint-plugin-react-hooks": "^5.0.0",
-    "eslint-plugin-tsdoc": "^0.4.0",
+    "eslint-plugin-tsdoc": "^0.5.0",
     "globals": "^16.0.0",
     "prettier": "^3.0.0",
     "typescript": ">=4.8.4",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrplf/eslint-config",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "type": "module",
   "description": "The XRPL Foundation's base TypeScript ESLint config, following our styleguide",
   "keywords": [

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrplf/eslint-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "The XRPL Foundation's base TypeScript ESLint config, following our styleguide",
   "keywords": [
     "eslint",

--- a/packages/eslint-config/rules/@typescript-eslint.js
+++ b/packages/eslint-config/rules/@typescript-eslint.js
@@ -1,8 +1,8 @@
 /* eslint-disable max-lines, max-len -- Required here due to many overrides */
 
-const tseslint = require('typescript-eslint')
+import tseslint from 'typescript-eslint'
 
-const common = require('./common')
+import common from './common.js'
 
 const baseConfig = [
   {
@@ -439,7 +439,7 @@ const baseConfig = [
       // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-as-const.md
       '@typescript-eslint/prefer-as-const': 'warn',
 
-      // Prefer a ‘for-of’ loop over a standard ‘for’ loop if the index is only used to access the array being iterated.
+      // Prefer a 'for-of' loop over a standard 'for' loop if the index is only used to access the array being iterated.
       // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-for-of.md
       '@typescript-eslint/prefer-for-of': 'error',
 
@@ -684,7 +684,7 @@ const baseConfig = [
       '@typescript-eslint/no-useless-constructor': 'error',
 
       // Enforce the consistent use of either backticks, double, or single quotes
-      // Usually, you don’t need this rule at all with Prettier. But there are two cases where it could be useful:
+      // Usually, you don't need this rule at all with Prettier. But there are two cases where it could be useful:
       // - To enforce the use of backticks rather than single or double quotes for strings.
       // - To forbid backticks where regular strings could have been used.
       // https://eslint.org/docs/rules/quotes
@@ -874,4 +874,4 @@ const baseConfig = [
   },
 ]
 
-module.exports = tseslint.config(tseslint.configs.eslintRecommended, baseConfig)
+export default tseslint.config(tseslint.configs.eslintRecommended, baseConfig)

--- a/packages/eslint-config/rules/array-func.js
+++ b/packages/eslint-config/rules/array-func.js
@@ -1,8 +1,3 @@
-const { FlatCompat } = require('@eslint/eslintrc')
-const arrayFunc = require('eslint-plugin-array-func')
+import arrayFunc from 'eslint-plugin-array-func'
 
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-})
-
-module.exports = compat.config(arrayFunc.configs.all)
+export default [arrayFunc.configs.all]

--- a/packages/eslint-config/rules/common.js
+++ b/packages/eslint-config/rules/common.js
@@ -1,6 +1,6 @@
 // Common paths and data for other rules
 
-module.exports = {
+export default {
   testPaths: ['test/**/*.ts', 'test/**/*.js', '*.test.ts', '*.test.js'],
   typeDeclarationPaths: ['*.d.ts'],
 }

--- a/packages/eslint-config/rules/eslint-comments.js
+++ b/packages/eslint-config/rules/eslint-comments.js
@@ -1,6 +1,6 @@
-const commentsConfig = require('@eslint-community/eslint-plugin-eslint-comments/configs')
+import commentsConfig from '@eslint-community/eslint-plugin-eslint-comments/configs'
 
-module.exports = [
+export default [
   commentsConfig.recommended,
   {
     rules: {

--- a/packages/eslint-config/rules/eslint-core/best-practices.js
+++ b/packages/eslint-config/rules/eslint-core/best-practices.js
@@ -1,4 +1,4 @@
-module.exports = [
+export default [
   {
     rules: {
       // enforces getter/setter pairs in objects and classes

--- a/packages/eslint-config/rules/eslint-core/errors.js
+++ b/packages/eslint-config/rules/eslint-core/errors.js
@@ -1,7 +1,7 @@
-module.exports = [
+export default [
   {
     rules: {
-      // Enforce “for” loop update clause moving the counter in the right direction
+      // Enforce "for" loop update clause moving the counter in the right direction
       // https://eslint.org/docs/rules/for-direction
       'for-direction': 'error',
 

--- a/packages/eslint-config/rules/eslint-core/es6.js
+++ b/packages/eslint-config/rules/eslint-core/es6.js
@@ -1,4 +1,4 @@
-module.exports = [
+export default [
   {
     rules: {
       // verify super() callings in constructors

--- a/packages/eslint-config/rules/eslint-core/strict.js
+++ b/packages/eslint-config/rules/eslint-core/strict.js
@@ -1,4 +1,4 @@
-module.exports = [
+export default [
   {
     rules: {
       // TypeScript inserts `'use strict';` for us

--- a/packages/eslint-config/rules/eslint-core/style.js
+++ b/packages/eslint-config/rules/eslint-core/style.js
@@ -1,6 +1,6 @@
-const common = require('../common')
+import common from '../common.js'
 
-module.exports = [
+export default [
   {
     rules: {
       // require camel case names

--- a/packages/eslint-config/rules/eslint-core/variables.js
+++ b/packages/eslint-config/rules/eslint-core/variables.js
@@ -1,6 +1,6 @@
-const confusingBrowserGlobals = require('confusing-browser-globals')
+import confusingBrowserGlobals from 'confusing-browser-globals'
 
-module.exports = [
+export default [
   {
     rules: {
       // disallow deletion of variables

--- a/packages/eslint-config/rules/import.js
+++ b/packages/eslint-config/rules/import.js
@@ -1,8 +1,8 @@
-const importPlugin = require('eslint-plugin-import')
+import importPlugin from 'eslint-plugin-import'
 
-const common = require('./common')
+import common from './common.js'
 
-module.exports = [
+export default [
   importPlugin.flatConfigs.recommended,
   importPlugin.flatConfigs.typescript,
   {
@@ -233,7 +233,7 @@ module.exports = [
       // Some projects contain files which are not always meant to be executed in the same environment.
       // For example consider a web application that contains specific code for the server and
       // some specific code for the browser/client.
-      // In this case you don’t want to import server-only files in your client code.
+      // In this case you don't want to import server-only files in your client code.
       // In order to prevent such scenarios this rule allows you to define restricted zones where
       // you can forbid files from imported if they match a specific path.
       // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-restricted-paths.md

--- a/packages/eslint-config/rules/jsdoc.js
+++ b/packages/eslint-config/rules/jsdoc.js
@@ -1,8 +1,8 @@
-const jsdocPlugin = require('eslint-plugin-jsdoc')
+import jsdocPlugin from 'eslint-plugin-jsdoc'
 
-const common = require('./common')
+import common from './common.js'
 
-module.exports = [
+export default [
   {
     plugins: {
       jsdoc: jsdocPlugin,

--- a/packages/eslint-config/rules/node.js
+++ b/packages/eslint-config/rules/node.js
@@ -1,8 +1,8 @@
-const nodePlugin = require('eslint-plugin-n')
+import nodePlugin from 'eslint-plugin-n'
 
-const common = require('./common')
+import common from './common.js'
 
-module.exports = [
+export default [
   nodePlugin.configs['flat/recommended'],
   {
     settings: {

--- a/packages/eslint-config/rules/prettier.js
+++ b/packages/eslint-config/rules/prettier.js
@@ -1,8 +1,8 @@
-const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended')
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
 
-const common = require('./common')
+import common from './common.js'
 
-module.exports = [
+export default [
   eslintPluginPrettierRecommended,
   {
     // These rules are disabled by default, but can be enabled as long as you have read documentation (which I have).
@@ -42,10 +42,10 @@ module.exports = [
       'no-tabs': ['warn', { allowIndentationTabs: true }],
 
       // Usually, Prettier takes care of following a maximum line length automatically.
-      // However, there are cases where Prettier can’t do anything, such as for long strings, regular expressions and comments.
-      // If you’d like to enforce an even stricter maximum line length policy than Prettier can
+      // However, there are cases where Prettier can't do anything, such as for long strings, regular expressions and comments.
+      // If you'd like to enforce an even stricter maximum line length policy than Prettier can
       // provide automatically, you can enable this rule.
-      // Just remember to keep max-len’s options and Prettier’s printWidth option in sync.
+      // Just remember to keep max-len's options and Prettier's printWidth option in sync.
       // https://eslint.org/docs/rules/max-len
       'max-len': [
         'warn',

--- a/packages/eslint-config/rules/react.js
+++ b/packages/eslint-config/rules/react.js
@@ -1,8 +1,8 @@
-const jsxA11yPlugin = require('eslint-plugin-jsx-a11y')
-const reactPlugin = require('eslint-plugin-react')
-const reactHooksPlugin = require('eslint-plugin-react-hooks')
+import jsxA11yPlugin from 'eslint-plugin-jsx-a11y'
+import reactPlugin from 'eslint-plugin-react'
+import reactHooksPlugin from 'eslint-plugin-react-hooks'
 
-module.exports = [
+export default [
   jsxA11yPlugin.flatConfigs.recommended,
   reactPlugin.configs.flat.recommended,
   reactPlugin.configs.flat['jsx-runtime'],

--- a/packages/eslint-config/rules/tsdoc.js
+++ b/packages/eslint-config/rules/tsdoc.js
@@ -1,6 +1,6 @@
-const tsdocPlugin = require('eslint-plugin-tsdoc')
+import tsdocPlugin from 'eslint-plugin-tsdoc'
 
-module.exports = [
+export default [
   {
     plugins: {
       tsdoc: tsdocPlugin,


### PR DESCRIPTION
This PR accomplishes the following:
- Upgrades `eslint-plugin-tsdoc` dependency from 0.4.0 to 0.5.0. 
- Upgrades the dependency `eslint-plugin-array-doc` from `4.0.0` to `5.1.0`. Due to this upgrade, the `eslint-config` had to be converted from CommonJS to an ESM compatible implementation. This is because the said dependency only works with ESM modules.
- Upgrade the major version of the `eslint-config` repository to indicate the upgrade of dependencies.

Note: This PR is blocking the upgrade of xrpl.js mono repository with a similar dependency upgrade. The failing PR details can be found here: https://github.com/XRPLF/xrpl.js/pull/3176/changes