### PR TITLE
chore: upgrade handlebars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6087,9 +6087,9 @@
       "peer": true
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Update `handlebars` to resolve this critical security issue.

Vulnerable code in [package-lock.json:6089](https://github.com/XRPLF/typescript-style/blob/d33361bd8451b5ddecbbd23f90cb90c891403d4e/package-lock.json#L6089)

Affected versions of handlebars are vulnerable to Improper Control of Generation of Code ('Code Injection') / Improper Encoding or Escaping of Output / Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting'). The Handlebars CLI precompiler allows arbitrary JavaScript injection by embedding unescaped template filenames and CLI option values such as `--namespace`, `--commonjs`, and `--handlebarPath` directly into generated output. An attacker who can control these inputs can cause malicious code to execute when the precompiled bundle is loaded in Node.js or a browser.

Severity: High

Current version: 4.7.8

Recommended fix version: 4.7.9